### PR TITLE
Properly re-export everything from the reconciler module

### DIFF
--- a/example/resume/index.jsx
+++ b/example/resume/index.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import DocxRender from "../../";
+import { renderAsyncDocument } from "../../";
 import { MainLayoutTable } from "./mainLayoutTable";
 import { ResumeProvder } from "./hooks.js";
 
@@ -15,7 +15,7 @@ export const renderResume = async (resumeData, config) => {
   });
   const { locale, translations } = config;
   const i18n = new I18n({ locale, translations: translations.resume });
-  return DocxRender.renderAsyncDocument(
+  return renderAsyncDocument(
     <ResumeProvder resume={resume} config={config} i18n={i18n}>
       <section
         margings={{

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,1 @@
-import * as Reconciler from "./reconciler";
-
-export default {
-  renderAsyncDocument: Reconciler.renderAsyncDocument,
-};
+export * from "./reconciler";


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/web/javascript/reference/statements/export

`export * from ...` allows to properly re-export everything defined in another module (except for the default export, which should be done separately). 

I think we should stick to this way of exporting things, as it is a common practice used by many libraries. Example:
```js
// the main thing is exported as default, the additional stuff has named exports
import React, { useState } from "react";
```
